### PR TITLE
Fix compile errors under newest Rust.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Installation
 ```
 git clone https://github.com/xsleonard/rust-sdl2_image
 cd rust-sdl2_image
-rustpkg install sdl2_image
+rustc src/sdl2_image/lib.rs
+# OR if you are using the mac framework version
+rustc --cfg mac_framework src/sdl2_image/lib.rs
 ```
 
 Demo
 ----
 
 ```
-rustpkg install demo
-./bin/demo image.[png|jpg]
+rustc -L. src/demo/main.rs -o demo
+./demo image.[png|jpg]
 ```

--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -1,8 +1,8 @@
-#[crate_type = "bin"];
+#![crate_type = "bin"]
 
-extern mod sdl2;
-extern mod sdl2_image;
-extern mod native;
+extern crate sdl2;
+extern crate sdl2_image;
+extern crate native;
 
 use std::os;
 

--- a/src/sdl2_image/ffi.rs
+++ b/src/sdl2_image/ffi.rs
@@ -1,4 +1,4 @@
-extern mod sdl2;
+extern crate sdl2;
 
 use std::libc::{c_int, c_char};
 use sdl2::surface::ll::SDL_Surface;
@@ -93,4 +93,3 @@ pub fn IMG_SavePNG_RW(surface: *SDL_Surface, dst: *SDL_RWops,
                       freedst: c_int) -> c_int;
 
 }   // extern "C"
-

--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -1,11 +1,11 @@
-#[crate_id="sdl2_image#sdl2_image:0.1"];
-#[crate_type = "lib"];
-#[desc = "SDL2_image bindings and wrappers"];
-#[comment = "SDL2_image bindings and wrappers"];
-#[license = "MIT"];
+#![crate_id="sdl2_image#sdl2_image:0.1"]
+#![crate_type = "lib"]
+#![desc = "SDL2_image bindings and wrappers"]
+#![comment = "SDL2_image bindings and wrappers"]
+#![license = "MIT"]
 
 
-extern mod sdl2;
+extern crate sdl2;
 
 use std::libc::{c_int, c_char};
 use std::ptr;
@@ -34,6 +34,7 @@ mod others {
     extern {}
 }
 
+#[allow(non_camel_case_types, dead_code)]
 mod ffi;
 
 /// InitFlags are passed to init() to control which subsystem
@@ -41,7 +42,7 @@ mod ffi;
 // repr(C) "makes the size of the enum's discriminant the default
 // size of enums that the C ABI for the platform uses."
 #[repr(C)]
-#[deriving(Clone, Eq, IterBytes, ToStr)]
+#[deriving(Clone, Eq, Hash, Show)]
 pub enum InitFlag {
     InitJpg = ffi::IMG_INIT_JPG as int,
     InitPng = ffi::IMG_INIT_PNG as int,
@@ -57,9 +58,9 @@ pub struct SDLImageVersion {
     patch: int,
 }
 
-impl ToStr for SDLImageVersion {
-    fn to_str(&self) -> ~str {
-        format!("{}.{}.{}", self.major, self.minor, self.patch)
+impl ::std::fmt::Show for SDLImageVersion {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f.buf, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
 


### PR DESCRIPTION
ToStr => Show
mod => crate
add allow(non_camel_case_types, dead_code) to ffi
replace old rustpkg command in README
