### PR TITLE
fix compile error: struct field default now private

### DIFF
--- a/src/sdl2_image/ffi.rs
+++ b/src/sdl2_image/ffi.rs
@@ -13,9 +13,9 @@ pub static IMG_INIT_TIF: IMG_InitFlags = 0x00000004;
 pub static IMG_INIT_WEBP: IMG_InitFlags = 0x00000008;
 
 pub struct SDL_version {
-    major: int,
-    minor: int,
-    patch: int,
+    pub major: int,
+    pub minor: int,
+    pub patch: int,
 }
 
 extern "C" {


### PR DESCRIPTION
fix #1 .
As Rust struct fields are now private by default.
