### PR TITLE
fix SDL_version type error

### DIFF
--- a/src/sdl2_image/ffi.rs
+++ b/src/sdl2_image/ffi.rs
@@ -1,6 +1,6 @@
 extern crate sdl2;
 
-use std::libc::{c_int, c_char};
+use std::libc::{c_int, c_char, uint8_t};
 use sdl2::surface::ll::SDL_Surface;
 use sdl2::rwops::ll::SDL_RWops;
 use sdl2::render::ll::SDL_Texture;
@@ -13,9 +13,9 @@ pub static IMG_INIT_TIF: IMG_InitFlags = 0x00000004;
 pub static IMG_INIT_WEBP: IMG_InitFlags = 0x00000008;
 
 pub struct SDL_version {
-    pub major: int,
-    pub minor: int,
-    pub patch: int,
+    pub major: uint8_t,
+    pub minor: uint8_t,
+    pub patch: uint8_t,
 }
 
 extern "C" {

--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -9,6 +9,7 @@ extern crate sdl2;
 
 use std::libc::{c_int, c_char};
 use std::ptr;
+use std::fmt;
 use sdl2::surface::Surface;
 use sdl2::render::Texture;
 use sdl2::render::Renderer;
@@ -53,13 +54,13 @@ pub enum InitFlag {
 /// The version of the libSDL.so that you are linked to
 #[deriving(Eq, Clone)]
 pub struct SDLImageVersion {
-    major: int,
-    minor: int,
-    patch: int,
+    pub major: int,
+    pub minor: int,
+    pub patch: int,
 }
 
-impl ::std::fmt::Show for SDLImageVersion {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl fmt::Show for SDLImageVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f.buf, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
@@ -69,7 +70,7 @@ impl SDLImageVersion {
         //! Converts a raw *SDL_version to SDLImageVersion
         unsafe {
             let v = *sv;
-            SDLImageVersion{ major: v.major, minor: v.minor, patch: v.patch }
+            SDLImageVersion{ major: v.major as int, minor: v.minor as int, patch: v.patch as int }
         }
     }
 }


### PR DESCRIPTION
`SDL_version` was defined in SDL_version.h, and the field type is uint8_t, instead of int.

``` c
typedef struct SDL_version
{
    Uint8 major;        /**< major version */
    Uint8 minor;        /**< minor version */
    Uint8 patch;        /**< update version */
} SDL_version;
```

Current sdl2_image version is 2.0.0, makes uint8_t and int returning same result under little endian.
When I copied that code to my rust-sdl2_ttf repo, I got a wrong version number. As current sdl2_ttf version is 2.0.12.

BTW: this pull request also makes SDLImageVersion field public.
