### PR TITLE
Fix wrong Windows target OS label.

### DIFF
--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -32,7 +32,7 @@ mod mac {
     extern {}
 }
 
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 #[cfg(target_os="linux")]
 #[cfg(target_os="freebsd")]
 mod others {


### PR DESCRIPTION
The library fails to compile for Windows since the cfg label is not correct.
This should fix it.
