### PR TITLE
fix cfg of link attribute for window/linux/freebsd

### DIFF
--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -32,7 +32,7 @@ mod mac {
     extern {}
 }
 
-#[cfg(all(target_os="windows", target_os="linux", target_os="freebsd"))]
+#[cfg(any(target_os="windows", target_os="linux", target_os="freebsd"))]
 mod others {
     #[link(name="SDL2_image")]
     extern {}


### PR DESCRIPTION
I had to make this change to get it to compile/link correctly on linux.
