### PR TITLE
Change sdl2 dependency to use crates.io version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ name = "demo"
 path = "src/demo/main.rs"
 
 [dependencies.sdl2]
-
-git = "https://github.com/AngryLawyer/rust-sdl2.git"
+sdl2 = "^0"


### PR DESCRIPTION
Fix conflicts in projects that use the crates.io version of sdl2
