### PR TITLE
build with rust nightly 2014-01-04

### DIFF
--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -12,6 +12,7 @@ extern crate libc;
 
 use libc::{c_int, c_char};
 use std::ptr;
+use std::c_str::ToCStr;
 use sdl2::surface::Surface;
 use sdl2::render::Texture;
 use sdl2::render::Renderer;
@@ -71,7 +72,7 @@ impl LoadSurface for Surface {
     fn from_file(filename: &Path) -> SdlResult<Surface> {
         //! Loads an SDL Surface from a file
         unsafe {
-            let raw = ffi::IMG_Load(filename.to_c_str().unwrap());
+            let raw = ffi::IMG_Load(filename.to_c_str().into_inner());
             if raw == ptr::null() {
                 Err(get_error())
             } else {
@@ -98,7 +99,7 @@ impl SaveSurface for Surface {
         //! Saves an SDL Surface to a file
         unsafe {
             let status = ffi::IMG_SavePNG(self.raw(),
-                                          filename.to_c_str().unwrap());
+                                          filename.to_c_str().into_inner());
             if status != 0 {
                 Err(get_error())
             } else {
@@ -131,7 +132,7 @@ impl LoadTexture for Renderer {
         //! Loads an SDL Texture from a file
         unsafe {
             let raw = ffi::IMG_LoadTexture(self.raw(),
-                                           filename.to_c_str().unwrap());
+                                           filename.to_c_str().into_inner());
             if raw == ptr::null() {
                 Err(get_error())
             } else {
@@ -218,7 +219,7 @@ impl ImageRWops for RWops {
     }
     fn load_typed(&self, _type: &str) -> SdlResult<Surface> {
         let raw = unsafe {
-            ffi::IMG_LoadTyped_RW(self.raw(), 0, _type.to_c_str().unwrap())
+            ffi::IMG_LoadTyped_RW(self.raw(), 0, _type.to_c_str().into_inner())
         };
         to_surface_result(raw)
     }


### PR DESCRIPTION
Fixed a build error and deprecated item warning.

```
$ rustc --version
rustc 0.13.0-nightly (c6c786671 2015-01-04 00:50:59 +0000)
```

```
src/sdl2_image/lib.rs:74:46: 74:56 error: type `&std::path::posix::Path` does not implement any method in scope named `to_c_str`
src/sdl2_image/lib.rs:74             let raw = ffi::IMG_Load(filename.to_c_str().unwrap());
```