### PR TITLE
Fixes for current rust-sdl2 library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ path       = "src/sdl2_image/lib.rs"
 name = "demo"
 path = "src/demo/main.rs"
 
-[dependencies.sdl2]
-sdl2 = "^0"
+[dependencies]
+sdl2 = "0.0.*"
+sdl2-sys = "0.0.*"
+bitflags = "0.1"

--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -7,7 +7,6 @@ use std::os;
 
 mod video;
 
-#[main]
 fn main() {
     let args = os::args();
     if args.len() < 2 {

--- a/src/demo/video.rs
+++ b/src/demo/video.rs
@@ -1,7 +1,7 @@
 use sdl2;
 use sdl2_image;
 use sdl2_image::LoadSurface;
-// use sdl2_image::LoadTexture;
+use sdl2_image::LoadTexture;
 
 pub fn main(png: &Path) {
     sdl2::init(sdl2::INIT_VIDEO);
@@ -30,11 +30,11 @@ pub fn main(png: &Path) {
         Err(err) => panic!(format!("Failed to create surface: {}", err))
     };
 
-    // // Load a texture directly via the renderer
-    // let texture = match renderer.load_texture(png) {
-    //     Ok(texture) => texture,
-    //     Err(err) => panic!(format!("Could not set render target: {}", err))
-    // };
+    // Load a texture directly via the renderer
+    let texture = match renderer.load_texture(png) {
+        Ok(texture) => texture,
+        Err(err) => panic!(format!("Could not set render target: {}", err))
+    };
 
     let mut drawer = renderer.drawer();
     let _ = drawer.copy(&texture, None, None);

--- a/src/demo/video.rs
+++ b/src/demo/video.rs
@@ -36,14 +36,15 @@ pub fn main(png: &Path) {
     //     Err(err) => panic!(format!("Could not set render target: {}", err))
     // };
 
-    let _ = renderer.copy(&texture, None, None);
-    renderer.present();
+    let mut drawer = renderer.drawer();
+    let _ = drawer.copy(&texture, None, None);
+    drawer.present();
 
     'main : loop {
         'event : loop {
             match sdl2::event::poll_event() {
-                sdl2::event::Event::Quit(_) => break 'main,
-                sdl2::event::Event::KeyDown(_, _, key, _, _, _) => {
+                sdl2::event::Event::Quit{..} => break 'main,
+                sdl2::event::Event::KeyDown{ keycode: key, .. } => {
                     if key == sdl2::keycode::KeyCode::Escape {
                         break 'main
                     }

--- a/src/sdl2_image/ffi.rs
+++ b/src/sdl2_image/ffi.rs
@@ -1,11 +1,12 @@
 extern crate sdl2;
+extern crate "sdl2-sys" as sdl2_sys;
 
 use libc::{c_int, c_char};
-use sdl2::surface::ll::SDL_Surface;
-use sdl2::rwops::ll::SDL_RWops;
-use sdl2::render::ll::SDL_Texture;
-use sdl2::render::ll::SDL_Renderer;
-use sdl2::version::ll::SDL_version;
+use sdl2_sys::surface::SDL_Surface;
+use sdl2_sys::rwops::SDL_RWops;
+use sdl2_sys::render::SDL_Texture;
+use sdl2_sys::render::SDL_Renderer;
+use sdl2_sys::version::SDL_version;
 
 pub type IMG_InitFlags = c_int;
 pub const IMG_INIT_JPG: IMG_InitFlags = 0x00000001;

--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -122,7 +122,7 @@ impl SaveSurface for Surface {
 }
 
 /// Method extensions for creating Textures from a Renderer
-/*pub trait LoadTexture {
+pub trait LoadTexture {
     fn load_texture(&self, filename: &Path) -> SdlResult<Texture>;
 }
 
@@ -134,11 +134,11 @@ impl LoadTexture for Renderer {
             if raw == ptr::null() {
                 Err(get_error())
             } else {
-                Ok(Texture{ raw: raw, owned: true, _marker: ContravariantLifetime })
+                Ok(Texture::from_ll(raw))
             }
         }
     }
-}*/
+}
 
 pub fn init(flags: InitFlag) -> InitFlag {
     //! Initializes SDL2_image with InitFlags and returns which

--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -1,11 +1,13 @@
-#![feature(macro_rules)]
-
 #![crate_name="sdl2_image"]
 #![crate_type = "lib"]
 
 
 extern crate sdl2;
+extern crate "sdl2-sys" as sdl2_sys;
 extern crate libc;
+
+#[macro_use]
+extern crate bitflags;
 
 use libc::{c_int, c_char};
 use std::ptr;
@@ -17,6 +19,7 @@ use sdl2::rwops::RWops;
 use sdl2::version::Version;
 use sdl2::get_error;
 use sdl2::SdlResult;
+use std::marker::ContravariantLifetime;
 
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
@@ -119,7 +122,7 @@ impl SaveSurface for Surface {
 }
 
 /// Method extensions for creating Textures from a Renderer
-pub trait LoadTexture {
+/*pub trait LoadTexture {
     fn load_texture(&self, filename: &Path) -> SdlResult<Texture>;
 }
 
@@ -131,11 +134,11 @@ impl LoadTexture for Renderer {
             if raw == ptr::null() {
                 Err(get_error())
             } else {
-                Ok(Texture{ raw: raw, owned: true })
+                Ok(Texture{ raw: raw, owned: true, _marker: ContravariantLifetime })
             }
         }
     }
-}
+}*/
 
 pub fn init(flags: InitFlag) -> InitFlag {
     //! Initializes SDL2_image with InitFlags and returns which
@@ -159,7 +162,7 @@ pub fn get_linked_version() -> Version {
 }
 
 #[inline]
-fn to_surface_result(raw: *const sdl2::surface::ll::SDL_Surface) -> SdlResult<Surface> {
+fn to_surface_result(raw: *const sdl2_sys::surface::SDL_Surface) -> SdlResult<Surface> {
     if raw == ptr::null() {
         Err(get_error())
     } else {


### PR DESCRIPTION
I commented out the load texture ( from path ) functionality because I didn't find a way to create the texture without changes from the sdl2 library.