### PR TITLE
Fixed mutability mismatch in calls to rust-sdl2's Surface::from_ll

### DIFF
--- a/src/sdl2_image/ffi.rs
+++ b/src/sdl2_image/ffi.rs
@@ -34,16 +34,16 @@ pub fn IMG_Quit();
 // surface afterwards by calling:
 //  SDL_SetColorKey(image, SDL_RLEACCEL, image->format->colorkey);
 pub fn IMG_LoadTyped_RW(src: *const SDL_RWops, freesrc: c_int,
-                        fmt: *const c_char) -> *const SDL_Surface;
+                        fmt: *const c_char) -> *mut SDL_Surface;
 
 // Convenience functions
-pub fn IMG_Load(file: *const c_char) -> *const SDL_Surface;
-pub fn IMG_Load_RW(src: *const SDL_RWops, freesrc: c_int) -> *const SDL_Surface;
+pub fn IMG_Load(file: *const c_char) -> *mut SDL_Surface;
+pub fn IMG_Load_RW(src: *const SDL_RWops, freesrc: c_int) -> *mut SDL_Surface;
 
 // Load an image directly into a render texture.
 // Requires SDL2
 pub fn IMG_LoadTexture(renderer: *const SDL_Renderer,
-                       file: *const c_char) -> *const SDL_Texture;
+                       file: *const c_char) -> *mut SDL_Texture;
 pub fn IMG_LoadTexture_RW(renderer: *const SDL_Renderer, src: *const SDL_RWops,
                           freesrc: c_int) -> *const SDL_Texture;
 pub fn IMG_LoadTextureTyped_RW(renderer: *const SDL_Renderer, src: *const SDL_RWops,
@@ -66,26 +66,26 @@ pub fn IMG_isXV(src: *const SDL_RWops) -> c_int;
 pub fn IMG_isWEBP(src: *const SDL_RWops) -> c_int;
 
 // Individual loading functions
-pub fn IMG_LoadICO_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadCUR_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadBMP_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadGIF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadJPG_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadLBM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadPCX_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadPNG_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadPNM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadTGA_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadTIF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadXCF_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadXPM_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadXV_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_LoadWEBP_RW(src: *const SDL_RWops) -> *const SDL_Surface;
-pub fn IMG_ReadXPMFromArray(xpm: *const *const c_char) -> *const SDL_Surface;
+pub fn IMG_LoadICO_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadCUR_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadBMP_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadGIF_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadJPG_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadLBM_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadPCX_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadPNG_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadPNM_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadTGA_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadTIF_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadXCF_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadXPM_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadXV_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_LoadWEBP_RW(src: *const SDL_RWops) -> *mut SDL_Surface;
+pub fn IMG_ReadXPMFromArray(xpm: *const *const c_char) -> *mut SDL_Surface;
 
 // Individual saving functions
-pub fn IMG_SavePNG(surface: *const SDL_Surface, file: *const c_char) -> c_int;
-pub fn IMG_SavePNG_RW(surface: *const SDL_Surface, dst: *const SDL_RWops,
+pub fn IMG_SavePNG(surface: *mut SDL_Surface, file: *const c_char) -> c_int;
+pub fn IMG_SavePNG_RW(surface: *mut SDL_Surface, dst: *const SDL_RWops,
                       freedst: c_int) -> c_int;
 
 }   // extern "C"

--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -72,7 +72,7 @@ impl<'a> LoadSurface for Surface<'a> {
         //! Loads an SDL Surface from a file
         unsafe {
             let raw = ffi::IMG_Load(CString::new(filename.to_str().unwrap()).unwrap().as_ptr());
-            if raw == ptr::null() {
+            if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
                 Ok(Surface::from_ll(raw, true))
@@ -84,7 +84,7 @@ impl<'a> LoadSurface for Surface<'a> {
         //! Loads an SDL Surface from XPM data
         unsafe {
             let raw = ffi::IMG_ReadXPMFromArray(xpm as *const *const c_char);
-            if raw == ptr::null() {
+            if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
                 Ok(Surface::from_ll(raw, true))
@@ -130,7 +130,7 @@ impl<'a> LoadTexture for Renderer<'a> {
         //! Loads an SDL Texture from a file
         unsafe {
             let raw = ffi::IMG_LoadTexture(self.raw(), CString::new(filename.to_str().unwrap()).unwrap().as_ptr());
-            if raw == ptr::null() {
+            if raw == ptr::null_mut() {
                 Err(get_error())
             } else {
                 Ok(Texture::from_ll(self, raw))
@@ -156,13 +156,13 @@ pub fn quit() {
 pub fn get_linked_version() -> Version {
     //! Returns the version of the dynamically linked SDL_image library
     unsafe {
-        Version::from_ll(ffi::IMG_Linked_Version())
+        Version::from_ll(*ffi::IMG_Linked_Version())
     }
 }
 
 #[inline]
-fn to_surface_result<'a>(raw: *const sys::surface::SDL_Surface) -> SdlResult<Surface<'a>> {
-    if raw == ptr::null() {
+fn to_surface_result<'a>(raw: *mut sys::surface::SDL_Surface) -> SdlResult<Surface<'a>> {
+    if raw == ptr::null_mut() {
         Err(get_error())
     } else {
         unsafe { Ok(Surface::from_ll(raw, true)) }


### PR DESCRIPTION
This PR just replaces *const with *mut where required to compile against latest sdl2.