### PR TITLE
update to sdl2 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/sdl2_image/lib.rs"
 [dependencies]
 bitflags = "0.1.1"
 libc = "0.1.6"
-sdl2 = "0.6"
+sdl2 = "0.8"
 sdl2-sys = "0.6"
 
 [[bin]]

--- a/src/demo/video.rs
+++ b/src/demo/video.rs
@@ -6,9 +6,10 @@ use sdl2::keyboard::Keycode;
 
 pub fn main(png: &Path) {
 
-    let mut context = sdl2::init().video().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
     sdl2_image::init(INIT_PNG | INIT_JPG);
-    let window = context.window("rust-sdl2 demo: Video", 800, 600)
+    let window = video_subsystem.window("rust-sdl2 demo: Video", 800, 600)
       .position_centered()
       .build()
       .unwrap();
@@ -20,7 +21,7 @@ pub fn main(png: &Path) {
     renderer.present();
 
     'mainloop: loop {
-        for event in context.event_pump().poll_iter() {
+        for event in sdl_context.event_pump().unwrap().poll_iter() {
             match event {
                 Event::Quit{..} |
                 Event::KeyDown {keycode: Option::Some(Keycode::Escape), ..} =>


### PR DESCRIPTION
I'm not able to use this with recent versions of https://github.com/AngryLawyer/rust-sdl2. I get a linking error for sdl2-sys:

```
native library `SDL2` is being linked to by more than one package, and can only be linked to by one package

  sdl2-sys v0.6.2 (https://github.com/AngryLawyer/rust-sdl2#1c55d25e)
  sdl2-sys v0.6.2
```

Updating the dependency on rust-sdl2 to 0.8.0 resolves this.