### PR TITLE
Put Sized bound on LoadSurface trait

### DIFF
--- a/src/sdl2_image/lib.rs
+++ b/src/sdl2_image/lib.rs
@@ -52,7 +52,7 @@ bitflags! {
 }
 
 /// Static method extensions for creating Surfaces
-pub trait LoadSurface {
+pub trait LoadSurface: Sized {
     // Self is only returned here to type hint to the compiler.
     // The syntax for type hinting in this case is not yet defined.
     // The intended return value is SdlResult<~Surface>.


### PR DESCRIPTION
This fixes a warning on nightly Rust (which will later become a hard error).

See https://github.com/rust-lang/rfcs/pull/1214.