### PR TITLE
Bump the version of SDL2 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdl2_image"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["xsleonard"]
 description = "SDL2_image bindings and wrappers"
 license = "MIT"
@@ -14,7 +14,7 @@ path = "src/sdl2_image/lib.rs"
 [dependencies]
 bitflags = "0.1.1"
 libc = "0.1.6"
-sdl2 = "0.8"
+sdl2 = "0.9"
 sdl2-sys = "0.6"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cargo.toml file:
 
 ```toml
 [dependencies]
-sdl2_image = "0.2.1"
+sdl2_image = "0.3"
 ```
 
 Or, to reference this repository directly:


### PR DESCRIPTION
To make the extension trait compatible with the newest version of the SDL2 bindings :)