### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/sdl2_image/lib.rs"
 bitflags = "^0.3.2"
 libc = "^0.1"
 sdl2 = "0.12.0"
-sdl2-sys = "0.7.0"
+sdl2-sys = "0.8.0"
 
 [[bin]]
 name = "demo"


### PR DESCRIPTION
We need to bump version for sdl2-sys, as if we use 0.7.0 it will not compile with other libs that use 0.8.0.
I've tested locally - it works fine with sdl2-sys v0.8.0.